### PR TITLE
Python3 8 2 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,4 +35,7 @@ following message:
 
 ## Requirements:
 * Python3.7
-* The Python packages specified in requirements.txt
+* The Python packages specified in requirements3_7.txt
+
+* Python3.8.2
+* The Python packages specified in requirements3_8_2.txt

--- a/requirements_python3_7.txt
+++ b/requirements_python3_7.txt
@@ -1,4 +1,4 @@
 Flask==1.1.1
 Flask-RESTful==0.3.7
 Flask-Script==2.0.6
-pyodbc==4.0.30
+pyodbc==4.0.28

--- a/requirements_python3_7.txt
+++ b/requirements_python3_7.txt
@@ -1,4 +1,4 @@
 Flask==1.1.1
 Flask-RESTful==0.3.7
 Flask-Script==2.0.6
-pyodbc==4.0.28
+pyodbc==4.0.30

--- a/requirements_python3_8_2.txt
+++ b/requirements_python3_8_2.txt
@@ -1,0 +1,4 @@
+Flask==1.1.1
+Flask-RESTful==0.3.7
+Flask-Script==2.0.6
+pyodbc==4.0.30


### PR DESCRIPTION
Just adding support for python 3.8.2
The pyodbc module will not be imported if not on a newer version. 
Bug tracker: https://github.com/mkleehammer/pyodbc/issues/663